### PR TITLE
修正重複log

### DIFF
--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -2,7 +2,7 @@
 <html lang="zh-TW">
   <head>
     <meta charset="UTF-8" />
-    <title>7 Days To Die Dedicated Server Plus 管理後台 1.0.3</title>
+    <title>7DTD-DS-P 管理後台 1.0.3</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="css/base.css" />
     <link rel="stylesheet" href="css/layout.css" />

--- a/src/web/public/lib/archive.js
+++ b/src/web/public/lib/archive.js
@@ -12,6 +12,17 @@ function ensureDir(p) {
   if (!fs.existsSync(p)) fs.mkdirSync(p, { recursive: true });
 }
 
+function tsNow() {
+  const d = new Date();
+  const YYYY = String(d.getFullYear());
+  const MM = String(d.getMonth() + 1).padStart(2, "0");
+  const DD = String(d.getDate()).padStart(2, "0");
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  const ss = String(d.getSeconds()).padStart(2, "0");
+  return `${YYYY}${MM}${DD}${hh}${mm}${ss}`;
+}
+
 function wrapArchive(promise) {
   return promise.then(() => ({ stdout: "", stderr: "" }));
 }
@@ -118,6 +129,18 @@ function zipSavesRoot(savesRoot, outZip) {
   );
 }
 
+async function createBackup(savesRoot, backupsDir) {
+  if (!savesRoot || !fs.existsSync(savesRoot)) {
+    throw new Error("來源存檔根目錄不存在");
+  }
+  ensureDir(backupsDir);
+  const ts = tsNow();
+  const zipName = `Saves-${ts}.zip`;
+  const outPath = path.resolve(path.join(backupsDir, zipName));
+  await zipSavesRoot(savesRoot, outPath);
+  return zipName;
+}
+
 function zipSingleWorldGame(savesRoot, world, name, outZip) {
   const gameDir = path.resolve(savesRoot, world, name);
   if (!fs.existsSync(gameDir)) throw new Error("來源存檔不存在");
@@ -196,4 +219,5 @@ module.exports = {
   zipSingleWorldGame,
   unzipArchive,
   inspectZip,
+  createBackup,
 };

--- a/src/web/public/lib/archive.js
+++ b/src/web/public/lib/archive.js
@@ -12,17 +12,6 @@ function ensureDir(p) {
   if (!fs.existsSync(p)) fs.mkdirSync(p, { recursive: true });
 }
 
-function tsNow() {
-  const d = new Date();
-  const YYYY = String(d.getFullYear());
-  const MM = String(d.getMonth() + 1).padStart(2, "0");
-  const DD = String(d.getDate()).padStart(2, "0");
-  const hh = String(d.getHours()).padStart(2, "0");
-  const mm = String(d.getMinutes()).padStart(2, "0");
-  const ss = String(d.getSeconds()).padStart(2, "0");
-  return `${YYYY}${MM}${DD}${hh}${mm}${ss}`;
-}
-
 function wrapArchive(promise) {
   return promise.then(() => ({ stdout: "", stderr: "" }));
 }
@@ -129,18 +118,6 @@ function zipSavesRoot(savesRoot, outZip) {
   );
 }
 
-async function createBackup(savesRoot, backupsDir) {
-  if (!savesRoot || !fs.existsSync(savesRoot)) {
-    throw new Error("來源存檔根目錄不存在");
-  }
-  ensureDir(backupsDir);
-  const ts = tsNow();
-  const zipName = `Saves-${ts}.zip`;
-  const outPath = path.resolve(path.join(backupsDir, zipName));
-  await zipSavesRoot(savesRoot, outPath);
-  return zipName;
-}
-
 function zipSingleWorldGame(savesRoot, world, name, outZip) {
   const gameDir = path.resolve(savesRoot, world, name);
   if (!fs.existsSync(gameDir)) throw new Error("來源存檔不存在");
@@ -219,5 +196,4 @@ module.exports = {
   zipSingleWorldGame,
   unzipArchive,
   inspectZip,
-  createBackup,
 };

--- a/src/web/public/lib/bytes.js
+++ b/src/web/public/lib/bytes.js
@@ -1,7 +1,0 @@
-function formatBytes(size) {
-  if (size >= 1024 ** 3) return `${(size / 1024 ** 3).toFixed(2)} GB`;
-  if (size >= 1024 ** 2) return `${(size / 1024 ** 2).toFixed(2)} MB`;
-  if (size >= 1024) return `${(size / 1024).toFixed(2)} KB`;
-  return `${size} B`;
-}
-module.exports = { formatBytes };

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -771,10 +771,7 @@ app.post("/api/backup", async (req, res) => {
       return http.sendErr(req, res, msg);
     }
     ensureDir(BACKUP_SAVES_DIR);
-    const tsStr = format(new Date(), "YYYYMMDDHHmmss");
-    const zipName = `Saves-${tsStr}.zip`;
-    const outPath = path.join(BACKUP_SAVES_DIR, zipName);
-    await archive.zipSavesRoot(savesRoot, outPath);
+    const zipName = await archive.createBackup(savesRoot, BACKUP_SAVES_DIR);
     const line = `✅ 備份完成: ${zipName}`;
     log(line);
     eventBus.push("backup", { text: line });

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -771,7 +771,10 @@ app.post("/api/backup", async (req, res) => {
       return http.sendErr(req, res, msg);
     }
     ensureDir(BACKUP_SAVES_DIR);
-    const zipName = await archive.createBackup(savesRoot, BACKUP_SAVES_DIR);
+    const tsStr = format(new Date(), "YYYYMMDDHHmmss");
+    const zipName = `Saves-${tsStr}.zip`;
+    const outPath = path.join(BACKUP_SAVES_DIR, zipName);
+    await archive.zipSavesRoot(savesRoot, outPath);
     const line = `✅ 備份完成: ${zipName}`;
     log(line);
     eventBus.push("backup", { text: line });

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -662,12 +662,14 @@ app.post("/api/install", (req, res) => {
       gameDirLocal,
       {
         onData: (data) => {
-          http.writeStamped(res, `[stdout] ${data}`);
-          eventBus.push("steamcmd", { level: "stdout", text: data });
+          let line = `[stdout] ${data}`;
+          http.writeStamped(res, line);
+          eventBus.push("steamcmd", { level: "stdout", text: line });
         },
         onError: (err) => {
-          http.writeStamped(res, `[stderr] ${err}`);
-          eventBus.push("steamcmd", { level: "stderr", text: err });
+          let line = `[stderr] ${err}`;
+          http.writeStamped(res, line);
+          eventBus.push("steamcmd", { level: "stderr", text: line });
         },
         onClose: (code) => {
           const line = `✅ 安裝 / 更新結束，Exit Code: ${code}`;
@@ -850,7 +852,7 @@ app.post("/api/start", async (req, res) => {
     const msg = `❌ 伺服器啟動失敗: ${err?.message || err}`;
     error(msg);
     eventBus.push("system", { level: "error", text: msg });
-    return http.sendErr(req, res, `❌ 啟動伺服器失敗:\n${err.message}`);
+    return http.sendErr(req, res, msg);
   }
 });
 
@@ -862,10 +864,10 @@ app.post("/api/stop", async (req, res) => {
         stopGameTail();
       } catch (_) {}
     stopGameTail = null;
-    const line = `✅ 關閉伺服器指令已發送`;
+    const line = `✅ 關閉伺服器指令已發送:\n${result}`;
     log(`${line}: ${result}`);
     eventBus.push("system", { text: line });
-    http.sendOk(req, res, `${line}:\n${result}`);
+    http.sendOk(req, res, `${line}`);
   } catch (err) {
     const msg = `❌ 關閉伺服器失敗: ${err.message}`;
     error(msg);
@@ -881,11 +883,12 @@ app.post("/api/telnet", async (req, res) => {
 
   try {
     const result = await sendTelnetCommand(command);
+    let line = `> ${command}\n${result}`;
     eventBus.push("telnet", {
       level: "stdout",
-      text: `> ${command}\n${result}`,
+      text: line,
     });
-    http.sendOk(req, res, `✅ 結果:\n${result}`);
+    http.sendOk(req, res, line);
   } catch (err) {
     const msg = `❌ Telnet 連線失敗: ${err.message}`;
     eventBus.push("telnet", { level: "stderr", text: msg });

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -6,7 +6,6 @@ const net = require("net");
 const { format, ts } = require("./public/lib/time");
 const { log, error } = require("./public/lib/logger");
 const http = require("./public/lib/http");
-const { formatBytes } = require("./public/lib/bytes");
 const processManager = require("./public/lib/processManager");
 const archive = require("./public/lib/archive");
 const eventBus = require("./public/lib/eventBus");
@@ -14,7 +13,7 @@ const { tailFile } = require("./public/lib/tailer");
 const logParser = require("./public/lib/logParser");
 const serverConfigLib = require("./public/lib/serverConfig");
 const steamcmd = require("./public/lib/steamcmd");
-const { sendTelnetCommand, telnetStart } = require("./telnet");
+const { sendTelnetCommand, telnetStart } = require("./public/lib/telnet");
 
 if (process.platform === "win32") exec("chcp 65001 >NUL");
 


### PR DESCRIPTION
統一推送給client的訊息，避免出現重複訊息導致閱讀混亂
- 調整/api/install、/api/start、/api/stop、/api/telnet中，透過eventBus跟http res的向clinet推送的內容，將訊息調整為一致，這樣clinet收到訊息時會因為重複訊息的過濾而只顯示一次。